### PR TITLE
Change the root namespace of our solution

### DIFF
--- a/Chapter-1-initial-architecture/Src/Directory.Build.props
+++ b/Chapter-1-initial-architecture/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <AssemblyName>SuperSimpleArchitecture.$(MSBuildProjectName)</AssemblyName>
+        <AssemblyName>EvolutionaryArchitecture.$(MSBuildProjectName)</AssemblyName>
         <RootNamespace>$(AssemblyName)</RootNamespace>
         <TargetFramework>net7.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/Configuration/ConfigurationExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/Configuration/ConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Common.TestEngine.Configuration;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.Configuration;
 
 using System.Reflection;
 using Fitnet.Shared.Events.EventBus;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/Configuration/ConfigurationKeys.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/Configuration/ConfigurationKeys.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Common.TestEngine.Configuration;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.Configuration;
 
 internal static class ConfigurationKeys
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/DatabaseContainer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/DatabaseContainer.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Common.TestEngine;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine;
 
 using Testcontainers.PostgreSql;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/IntegrationEvents/Handlers/WebApplicationFactoryExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/IntegrationEvents/Handlers/WebApplicationFactoryExtensions.cs
@@ -1,7 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Common.TestEngine.IntegrationEvents.Handlers;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.IntegrationEvents.Handlers;
 
 using MediatR;
-using SuperSimpleArchitecture.Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Shared.Events;
 
 internal static class WebApplicationFactoryExtensions
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/SystemClock/FakeSystemClock.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/SystemClock/FakeSystemClock.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Common.TestEngine.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.SystemClock;
 
-using SuperSimpleArchitecture.Fitnet.Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 internal sealed class FakeSystemClock : ISystemClock
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestFaker.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestFaker.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
 
-using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract;
 
 internal sealed class PrepareContractRequestFaker : Faker<PrepareContractRequest>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestParameters.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestParameters.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
 
 internal sealed record PrepareContractRequestParameters(int MinAge, int MaxAge, int MinHeight, int MaxHeight)
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
@@ -1,7 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
 
-using SuperSimpleArchitecture.Fitnet.Contracts;
-using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+using EvolutionaryArchitecture.Fitnet.Contracts;
+using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract;
 using Common.TestEngine;
 using Common.TestEngine.Configuration;
 using Fitnet.Shared.ErrorHandling;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestParameters.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestParameters.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.SignContract;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Contracts.SignContract;
 
-using SuperSimpleArchitecture.Fitnet.Contracts;
+using EvolutionaryArchitecture.Fitnet.Contracts;
 
 internal record SignContractRequestParameters(string Url, DateTimeOffset SignedAt)
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -1,8 +1,8 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.SignContract;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Contracts.SignContract;
 
-using SuperSimpleArchitecture.Fitnet.Contracts;
-using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
-using SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+using EvolutionaryArchitecture.Fitnet.Contracts;
+using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract;
+using EvolutionaryArchitecture.Fitnet.Contracts.SignContract;
 using PrepareContract;
 using Common.TestEngine;
 using Common.TestEngine.Configuration;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Offers/Prepare/PassExpiredEventFaker.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Offers/Prepare/PassExpiredEventFaker.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Offers.Prepare;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Offers.Prepare;
 
-using SuperSimpleArchitecture.Fitnet.Passes.MarkPassAsExpired.Events;
+using EvolutionaryArchitecture.Fitnet.Passes.MarkPassAsExpired.Events;
 
 internal sealed class PassExpiredEventFaker : Faker<PassExpiredEvent>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Offers/Prepare/PrepareOfferTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Offers/Prepare/PrepareOfferTests.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Offers.Prepare;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Offers.Prepare;
 
 using Common.TestEngine;
 using Common.TestEngine.Configuration;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/MarkPassAsExpired/MarkPassAsExpiredTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/MarkPassAsExpired/MarkPassAsExpiredTests.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.MarkPassAsExpired;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Passes.MarkPassAsExpired;
 
 using Fitnet.Passes;
 using RegisterPass;
@@ -6,7 +6,7 @@ using Common.TestEngine;
 using Common.TestEngine.Configuration;
 using Fitnet.Shared.Events;
 using Fitnet.Shared.Events.EventBus;
-using SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
+using EvolutionaryArchitecture.Fitnet.Passes.RegisterPass;
 
 public sealed class MarkPassAsExpiredTests : IClassFixture<WebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassRequestFaker.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassRequestFaker.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
 
-using SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
+using EvolutionaryArchitecture.Fitnet.Passes.RegisterPass;
 
 internal sealed class RegisterPassRequestFaker : Faker<RegisterPassRequest>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
 
 using Common.TestEngine;
 using Common.TestEngine.Configuration;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesPerMonthReport/GenerateNewPassesPerMonthReportTests.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesPerMonthReport;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesPerMonthReport;
 
 using Common.TestEngine;
 using Common.TestEngine.Configuration;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesRegistrationsPerMonthReport/RegisterPassRequestFaker.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesRegistrationsPerMonthReport/RegisterPassRequestFaker.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesRegistrationsPerMonthReport;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesRegistrationsPerMonthReport;
 
-using SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
+using EvolutionaryArchitecture.Fitnet.Passes.RegisterPass;
 
 internal sealed class RegisterPassRequestFaker : Faker<RegisterPassRequest>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesRegistrationsPerMonthReport/TestData/PassRegistrationDateRange.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesRegistrationsPerMonthReport/TestData/PassRegistrationDateRange.cs
@@ -1,3 +1,3 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesRegistrationsPerMonthReport.TestData;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesRegistrationsPerMonthReport.TestData;
 
 internal sealed record PassRegistrationDateRange(DateTimeOffset From, DateTimeOffset To);

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesRegistrationsPerMonthReport/TestData/ReportTestCases.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Reports/GenerateNewPassesRegistrationsPerMonthReport/TestData/ReportTestCases.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesRegistrationsPerMonthReport.TestData;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Reports.GenerateNewPassesRegistrationsPerMonthReport.TestData;
 
 internal sealed class ReportTestCases : IEnumerable<object[]>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEvent.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
 
 using Fitnet.Shared.Events;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEventConsumer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEventConsumer.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
 
 using Fitnet.Shared.Events;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/InMemoryEventBusTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/InMemoryEventBusTests.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
 
 using Common.TestEngine;
 using Common.TestEngine.Configuration;

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/BusinessRuleValidatorTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/BusinessRuleValidatorTests.cs
@@ -1,6 +1,6 @@
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
-namespace SuperSimpleArchitecture.Fitnet.UnitTests.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.UnitTests.BusinessRulesEngine;
 
 public sealed class BusinessRuleValidatorTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/FakeBusinessRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/FakeBusinessRule.cs
@@ -1,6 +1,6 @@
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
-namespace SuperSimpleArchitecture.Fitnet.UnitTests.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.UnitTests.BusinessRulesEngine;
 
 internal sealed class FakeBusinessRule : IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRuleTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRuleTests.cs
@@ -1,7 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
+namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
 
-using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 public sealed class ContractCanBePreparedOnlyForAdultRuleTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRuleTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRuleTests.cs
@@ -1,7 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
+namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
 
-using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 public sealed class CustomerMustBeSmallerThanMaximumHeightLimitRuleTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparationTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparationTests.cs
@@ -1,7 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.UnitTests.Contracts.SignContract.BusinessRules;
+namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.SignContract.BusinessRules;
 
-using SuperSimpleArchitecture.Fitnet.Contracts.SignContract.BusinessRules;
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Contracts.SignContract.BusinessRules;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 public sealed class ContractCanOnlyBeSignedWithin30DaysFromPreparationTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/ExceptionMiddlewareTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/ExceptionMiddlewareTests.cs
@@ -1,10 +1,10 @@
-namespace SuperSimpleArchitecture.Fitnet.UnitTests;
+namespace EvolutionaryArchitecture.Fitnet.UnitTests;
 
 using System.Net;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using Shared.ErrorHandling;
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 public sealed class ExceptionMiddlewareTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/ApiPaths.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/ApiPaths.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet;
+namespace EvolutionaryArchitecture.Fitnet;
 
 internal static class ApiPaths
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/ContractsApiPaths.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/ContractsApiPaths.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts;
+namespace EvolutionaryArchitecture.Fitnet.Contracts;
 
 internal static class ContractsApiPaths
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/ContractsEndpoints.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/ContractsEndpoints.cs
@@ -1,6 +1,6 @@
-using SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+using EvolutionaryArchitecture.Fitnet.Contracts.SignContract;
 
-namespace SuperSimpleArchitecture.Fitnet.Contracts;
+namespace EvolutionaryArchitecture.Fitnet.Contracts;
 
 using PrepareContract;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/ContractsModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/ContractsModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts;
+namespace EvolutionaryArchitecture.Fitnet.Contracts;
 
 using Data.Database;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Contract.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Contract.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.Data;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Data;
 
 using PrepareContract.BusinessRules;
 using SignContract.BusinessRules;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/AutomaticMigrationsExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/AutomaticMigrationsExtensions.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/ContractEntityConfiguration.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/ContractEntityConfiguration.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/ContractsPersistence.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/ContractsPersistence.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/DatabaseModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/DatabaseModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddPreparedAtDate.Designer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddPreparedAtDate.Designer.cs
@@ -5,11 +5,11 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+using EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
 {
     [DbContext(typeof(ContractsPersistence))]
     [Migration("20230407115944_AddPreparedAtDate")]
@@ -26,7 +26,7 @@ namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigratio
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("SuperSimpleArchitecture.Fitnet.Contracts.Data.Contract", b =>
+            modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Contracts.Data.Contract", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddPreparedAtDate.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddPreparedAtDate.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
 {
     /// <inheritdoc />
     public partial class AddPreparedAtDate : Migration

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddSignedAtDate.Designer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddSignedAtDate.Designer.cs
@@ -5,11 +5,11 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+using EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
 {
     [DbContext(typeof(ContractsPersistence))]
     [Migration("20230407123603_AddSignedAtDate")]
@@ -26,7 +26,7 @@ namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigratio
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("SuperSimpleArchitecture.Fitnet.Contracts.Data.Contract", b =>
+            modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Contracts.Data.Contract", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddSignedAtDate.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/AddSignedAtDate.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
 {
     /// <inheritdoc />
     public partial class AddSignedAtDate : Migration

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/ContractsPersistenceModelSnapshot.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/ContractsPersistenceModelSnapshot.cs
@@ -4,11 +4,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+using EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations
 {
     [DbContext(typeof(ContractsPersistence))]
     partial class ContractsPersistenceModelSnapshot : ModelSnapshot
@@ -23,7 +23,7 @@ namespace SuperSimpleArchitecture.Fitnet.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("SuperSimpleArchitecture.Fitnet.Contracts.Data.Contract", b =>
+            modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Contracts.Data.Contract", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/CreateContractsTable.Designer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/CreateContractsTable.Designer.cs
@@ -5,11 +5,11 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
+using EvolutionaryArchitecture.Fitnet.Contracts.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations
 {
     [DbContext(typeof(ContractsPersistence))]
     [Migration("20230322141428_Create_Contracts_Table")]
@@ -26,7 +26,7 @@ namespace SuperSimpleArchitecture.Fitnet.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("SuperSimpleArchitecture.Fitnet.Contracts.Data.Contract", b =>
+            modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Contracts.Data.Contract", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/CreateContractsTable.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Database/Migrations/CreateContractsTable.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations
 {
     /// <inheritdoc />
     public partial class CreateContractsTable : Migration

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
 
 using Shared.BusinessRulesEngine;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
 
 using Shared.BusinessRulesEngine;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract;
 
 using Data;
 using Data.Database;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/PrepareContractRequest.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/PrepareContractRequest.cs
@@ -1,3 +1,3 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract;
 
 public sealed record PrepareContractRequest(int CustomerAge, int CustomerHeight, DateTimeOffset PreparedAt);

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparation.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparation.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.SignContract.BusinessRules;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.SignContract.BusinessRules;
 
 using Shared.BusinessRulesEngine;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/SignContractEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/SignContractEndpoint.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.SignContract;
 
 using Data.Database;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/SignContractRequest.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/SignContractRequest.cs
@@ -1,3 +1,3 @@
-namespace SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+namespace EvolutionaryArchitecture.Fitnet.Contracts.SignContract;
 
 public sealed record SignContractRequest(DateTimeOffset SignedAt);

--- a/Chapter-1-initial-architecture/Src/Fitnet/Dockerfile
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Dockerfile
@@ -18,4 +18,4 @@ RUN dotnet publish "Fitnet.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "SuperSimpleArchitecture.Fitnet.dll"]
+ENTRYPOINT ["dotnet", "EvolutionaryArchitecture.Fitnet.dll"]

--- a/Chapter-1-initial-architecture/Src/Fitnet/Fitnet.csproj
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Fitnet.csproj
@@ -15,12 +15,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="SuperSimpleArchitecture.Fitnet.UnitTests" />
-        <InternalsVisibleTo Include="SuperSimpleArchitecture.Fitnet.IntegrationTests" />
+        <InternalsVisibleTo Include="EvolutionaryArchitecture.Fitnet.UnitTests" />
+        <InternalsVisibleTo Include="EvolutionaryArchitecture.Fitnet.IntegrationTests" />
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="SuperSimpleArchitecture.Fitnet.IntegrationTests" />
+        <InternalsVisibleTo Include="EvolutionaryArchitecture.Fitnet.IntegrationTests" />
     </ItemGroup>
     
 </Project>

--- a/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/OfferPrepareEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/OfferPrepareEvent.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Offers.Prepare;
+namespace EvolutionaryArchitecture.Fitnet.Offers.Prepare;
 
 using Shared.Events;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/PassExpiredEventHandler.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/PassExpiredEventHandler.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Offers.Prepare;
+namespace EvolutionaryArchitecture.Fitnet.Offers.Prepare;
 
 using Passes.MarkPassAsExpired.Events;
 using Shared.Events;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/AutomaticMigrationsExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/AutomaticMigrationsExtensions.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Passes.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/DatabaseModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/DatabaseModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Passes.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/Migrations/Create_Passes_Tables.Designer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/Migrations/Create_Passes_Tables.Designer.cs
@@ -5,11 +5,11 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SuperSimpleArchitecture.Fitnet.Passes.Data.Database;
+using EvolutionaryArchitecture.Fitnet.Passes.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations
 {
     [DbContext(typeof(PassesPersistence))]
     [Migration("20230321064710_Create_Passes_Tables")]
@@ -26,7 +26,7 @@ namespace SuperSimpleArchitecture.Fitnet.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("SuperSimpleArchitecture.Fitnet.Passes.Data.Pass", b =>
+            modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Passes.Data.Pass", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/Migrations/Create_Passes_Tables.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/Migrations/Create_Passes_Tables.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations
 {
     /// <inheritdoc />
     public partial class Create_Passes_Tables : Migration

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/Migrations/PassesPersistenceModelSnapshot.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/Migrations/PassesPersistenceModelSnapshot.cs
@@ -4,11 +4,11 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SuperSimpleArchitecture.Fitnet.Passes.Data.Database;
+using EvolutionaryArchitecture.Fitnet.Passes.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace EvolutionaryArchitecture.Fitnet.Migrations
 {
     [DbContext(typeof(PassesPersistence))]
     partial class PassesPersistenceModelSnapshot : ModelSnapshot
@@ -23,7 +23,7 @@ namespace SuperSimpleArchitecture.Fitnet.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("SuperSimpleArchitecture.Fitnet.Passes.Data.Pass", b =>
+            modelBuilder.Entity("EvolutionaryArchitecture.Fitnet.Passes.Data.Pass", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/PassEntityConfiguration.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/PassEntityConfiguration.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Passes.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/PassesPersistence.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Database/PassesPersistence.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.Data.Database;
+namespace EvolutionaryArchitecture.Fitnet.Passes.Data.Database;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Pass.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/Data/Pass.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.Data;
+namespace EvolutionaryArchitecture.Fitnet.Passes.Data;
 
 internal sealed class Pass
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/Events/PassExpiredEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/Events/PassExpiredEvent.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.MarkPassAsExpired.Events;
+namespace EvolutionaryArchitecture.Fitnet.Passes.MarkPassAsExpired.Events;
 
-using SuperSimpleArchitecture.Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Shared.Events;
 
 internal record PassExpiredEvent(Guid Id, Guid PassId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.MarkPassAsExpired;
+namespace EvolutionaryArchitecture.Fitnet.Passes.MarkPassAsExpired;
 
 using Data.Database;
 using Events;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/PassesApiPaths.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/PassesApiPaths.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes;
+namespace EvolutionaryArchitecture.Fitnet.Passes;
 
 internal static class PassesApiPaths
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/PassesEndpoints.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/PassesEndpoints.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes;
+namespace EvolutionaryArchitecture.Fitnet.Passes;
 
 using MarkPassAsExpired;
 using RegisterPass;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/PassesModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/PassesModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes;
+namespace EvolutionaryArchitecture.Fitnet.Passes;
 
 using Data.Database;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/RegisterEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/RegisterEndpoint.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
+namespace EvolutionaryArchitecture.Fitnet.Passes.RegisterPass;
 
 using Data;
 using Data.Database;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/RegisterPassRequest.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/RegisterPassRequest.cs
@@ -1,3 +1,3 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
+namespace EvolutionaryArchitecture.Fitnet.Passes.RegisterPass;
 
 public record RegisterPassRequest(Guid CustomerId, DateTimeOffset From, DateTimeOffset To);

--- a/Chapter-1-initial-architecture/Src/Fitnet/Program.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Program.cs
@@ -1,10 +1,10 @@
-using SuperSimpleArchitecture.Fitnet;
-using SuperSimpleArchitecture.Fitnet.Contracts;
-using SuperSimpleArchitecture.Fitnet.Passes;
-using SuperSimpleArchitecture.Fitnet.Reports;
-using SuperSimpleArchitecture.Fitnet.Shared.ErrorHandling;
-using SuperSimpleArchitecture.Fitnet.Shared.Events.EventBus;
-using SuperSimpleArchitecture.Fitnet.Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet;
+using EvolutionaryArchitecture.Fitnet.Contracts;
+using EvolutionaryArchitecture.Fitnet.Passes;
+using EvolutionaryArchitecture.Fitnet.Reports;
+using EvolutionaryArchitecture.Fitnet.Shared.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -45,7 +45,7 @@ app.MapReports();
 
 app.Run();
 
-namespace SuperSimpleArchitecture.Fitnet
+namespace EvolutionaryArchitecture.Fitnet
 {
     [UsedImplicitly]
     public sealed class Program

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/DataAccess/DatabaseAccessModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/DataAccess/DatabaseAccessModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.DataAccess;
+namespace EvolutionaryArchitecture.Fitnet.Reports.DataAccess;
 
 internal static class DatabaseAccessModule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/DataAccess/DatabaseConnectionFactory.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/DataAccess/DatabaseConnectionFactory.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.DataAccess;
+namespace EvolutionaryArchitecture.Fitnet.Reports.DataAccess;
 
 using System.Data;
 using Npgsql;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/DataAccess/IDatabaseConnectionFactory.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/DataAccess/IDatabaseConnectionFactory.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.DataAccess;
+namespace EvolutionaryArchitecture.Fitnet.Reports.DataAccess;
 
 using System.Data;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/INewPassesRegistrationPerMonthReportDataRetriever.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/INewPassesRegistrationPerMonthReportDataRetriever.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.DataRetriever;
+namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.DataRetriever;
 
 using Dtos;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
@@ -1,9 +1,9 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.DataRetriever;
+namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.DataRetriever;
 
 using Dapper;
 using Dtos;
-using SuperSimpleArchitecture.Fitnet.Reports.DataAccess;
-using SuperSimpleArchitecture.Fitnet.Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Reports.DataAccess;
+using EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 internal sealed class NewPassesRegistrationPerMonthReportDataRetriever : INewPassesRegistrationPerMonthReportDataRetriever
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/Dtos/NewPassesRegistrationsPerMonthDto.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/Dtos/NewPassesRegistrationsPerMonthDto.cs
@@ -1,3 +1,3 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.Dtos;
+namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.Dtos;
 
 public sealed record NewPassesRegistrationsPerMonthDto(int MonthOrder, string MonthName, long RegisteredPasses);

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/Dtos/NewPassesRegistrationsPerMonthResponse.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/Dtos/NewPassesRegistrationsPerMonthResponse.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.Dtos;
+namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport.Dtos;
 
 public sealed record NewPassesRegistrationsPerMonthResponse(IReadOnlyCollection<NewPassesRegistrationsPerMonthDto> PassesRegistrationsPerMonth)
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/GenerateNewPassesPerMonthReportEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/GenerateNewPassesPerMonthReportEndpoint.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport;
+namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport;
 
 using DataRetriever;
 using Dtos;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/GenerateNewPassesPerMonthReportModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/GenerateNewPassesPerMonthReportModule.cs
@@ -1,7 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport;
+namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrationsPerMonthReport;
 
 using DataRetriever;
-using SuperSimpleArchitecture.Fitnet.Reports.DataAccess;
+using EvolutionaryArchitecture.Fitnet.Reports.DataAccess;
 
 internal static class GenerateNewPassesPerMonthReportModule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/ReportsApiPaths.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/ReportsApiPaths.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports;
+namespace EvolutionaryArchitecture.Fitnet.Reports;
 
 internal static class ReportsApiPaths
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/ReportsEndpoints.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/ReportsEndpoints.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports;
+namespace EvolutionaryArchitecture.Fitnet.Reports;
 
 using GenerateNewPassesRegistrationsPerMonthReport;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/ReportsModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/ReportsModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Reports;
+namespace EvolutionaryArchitecture.Fitnet.Reports;
 
 using DataAccess;
 using GenerateNewPassesRegistrationsPerMonthReport;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/BusinessRulesEngine/BusinessRuleValidationException.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/BusinessRulesEngine/BusinessRuleValidationException.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 internal class BusinessRuleValidationException : InvalidOperationException
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/BusinessRulesEngine/BusinessRuleValidator.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/BusinessRulesEngine/BusinessRuleValidator.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 internal static class BusinessRuleValidator
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/BusinessRulesEngine/IBusinessRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/BusinessRulesEngine/IBusinessRule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 internal interface IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/ErrorHandling/ErrorHandlingExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/ErrorHandling/ErrorHandlingExtensions.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.ErrorHandling;
+namespace EvolutionaryArchitecture.Fitnet.Shared.ErrorHandling;
 
 internal static class ErrorHandlingExtensions
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/ErrorHandling/ExceptionMiddleware.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/ErrorHandling/ExceptionMiddleware.cs
@@ -1,8 +1,8 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.ErrorHandling;
+namespace EvolutionaryArchitecture.Fitnet.Shared.ErrorHandling;
 
 using System.Net;
 using System.Text.Json;
-using SuperSimpleArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 internal sealed class ExceptionMiddleware
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/EventBusModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/EventBusModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.Events.EventBus;
+namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus;
 
 using System.Reflection;
 using InMemory;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/IEventBus.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/IEventBus.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.Events.EventBus;
+namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus;
 
 internal interface IEventBus
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/InMemory/InMemoryEventBus.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/InMemory/InMemoryEventBus.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus.InMemory;
 
 using MediatR;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/InMemory/InMemoryEventBusModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/EventBus/InMemory/InMemoryEventBusModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus.InMemory;
 
 using System.Reflection;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/IIntegrationEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/IIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.Events;
+namespace EvolutionaryArchitecture.Fitnet.Shared.Events;
 
 using MediatR;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/IIntegrationEventHandler.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/Events/IIntegrationEventHandler.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.Events;
+namespace EvolutionaryArchitecture.Fitnet.Shared.Events;
 
 using MediatR;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/SystemClock/ISystemClock.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/SystemClock/ISystemClock.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 internal interface ISystemClock
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/SystemClock/SystemClock.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/SystemClock/SystemClock.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 internal sealed class SystemClock : ISystemClock
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Shared/SystemClock/SystemClockModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Shared/SystemClock/SystemClockModule.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.Shared.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 internal static class SystemClockModule
 {


### PR DESCRIPTION
This PR includes change of the root namespace called:

- SuperSimpleArchitecture

to:

- EvolutionaryArchitecture

After getting this version of code it is suggested to drop all local files from folders /bin, /obj and some DotSettings for user