### PR TITLE
Create scaffold projects for passes

### DIFF
--- a/Chapter-2-modules-separation/Src/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
+++ b/Chapter-2-modules-separation/Src/Fitnet.Passes.Api/Fitnet.Passes.Api.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/Chapter-2-modules-separation/Src/Fitnet.Passes.DataAccess/Fitnet.Passes.DataAccess.csproj
+++ b/Chapter-2-modules-separation/Src/Fitnet.Passes.DataAccess/Fitnet.Passes.DataAccess.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/Chapter-2-modules-separation/Src/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
+++ b/Chapter-2-modules-separation/Src/Fitnet.Passes.IntegrationTests/Fitnet.Passes.IntegrationTests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+</Project>

--- a/Chapter-2-modules-separation/Src/Fitnet.sln
+++ b/Chapter-2-modules-separation/Src/Fitnet.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet", "Fitnet\Fitnet.csproj", "{F794BA2B-0F1A-4D1C-93B8-32B916FDEDEC}"
 EndProject
@@ -30,7 +30,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Contracts.Infrastruc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Common.Core", "Fitnet.Common.Core\Fitnet.Common.Core.csproj", "{7BE78BF9-6419-412C-A766-F80ADFF2CF49}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Passes", "Passes", "{732AD772-11C2-4DCC-B6DC-D59EABEF335B}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Passes.Api", "Fitnet.Passes.Api\Fitnet.Passes.Api.csproj", "{BD63790A-A2CD-494F-BA6B-66FB43CA5461}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Passes.DataAccess", "Fitnet.Passes.DataAccess\Fitnet.Passes.DataAccess.csproj", "{BE4822A9-64F1-449B-9EBE-918BAA67CD07}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -90,6 +94,10 @@ Global
 		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9A6E0883-EE26-4A50-9114-AF1EDD82EB94} = {7D3193F0-C731-4683-893F-53CE8087D7E2}
@@ -102,5 +110,6 @@ Global
 		{2C77D377-30F5-40C9-81CF-43E644427A03} = {8ECA26D2-A5A3-4CC5-BED7-F33422EACEAF}
 		{7BE78BF9-6419-412C-A766-F80ADFF2CF49} = {8ECA26D2-A5A3-4CC5-BED7-F33422EACEAF}
 		{BD63790A-A2CD-494F-BA6B-66FB43CA5461} = {732AD772-11C2-4DCC-B6DC-D59EABEF335B}
+		{BE4822A9-64F1-449B-9EBE-918BAA67CD07} = {732AD772-11C2-4DCC-B6DC-D59EABEF335B}
 	EndGlobalSection
 EndGlobal

--- a/Chapter-2-modules-separation/Src/Fitnet.sln
+++ b/Chapter-2-modules-separation/Src/Fitnet.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet", "Fitnet\Fitnet.csproj", "{F794BA2B-0F1A-4D1C-93B8-32B916FDEDEC}"
 EndProject
@@ -29,6 +29,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Contracts.Infrastructure", "Fitnet.Contracts.Infrastructure\Fitnet.Contracts.Infrastructure.csproj", "{01B268D3-BBAE-4DA3-B9AB-B04216A2E2D6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Common.Core", "Fitnet.Common.Core\Fitnet.Common.Core.csproj", "{7BE78BF9-6419-412C-A766-F80ADFF2CF49}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Passes.Api", "Fitnet.Passes.Api\Fitnet.Passes.Api.csproj", "{BD63790A-A2CD-494F-BA6B-66FB43CA5461}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,6 +86,10 @@ Global
 		{7BE78BF9-6419-412C-A766-F80ADFF2CF49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BE78BF9-6419-412C-A766-F80ADFF2CF49}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BE78BF9-6419-412C-A766-F80ADFF2CF49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD63790A-A2CD-494F-BA6B-66FB43CA5461}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9A6E0883-EE26-4A50-9114-AF1EDD82EB94} = {7D3193F0-C731-4683-893F-53CE8087D7E2}
@@ -95,5 +101,6 @@ Global
 		{B1C5A9F4-AE1F-40D5-AA07-3BCC5E7D22AC} = {8ECA26D2-A5A3-4CC5-BED7-F33422EACEAF}
 		{2C77D377-30F5-40C9-81CF-43E644427A03} = {8ECA26D2-A5A3-4CC5-BED7-F33422EACEAF}
 		{7BE78BF9-6419-412C-A766-F80ADFF2CF49} = {8ECA26D2-A5A3-4CC5-BED7-F33422EACEAF}
+		{BD63790A-A2CD-494F-BA6B-66FB43CA5461} = {732AD772-11C2-4DCC-B6DC-D59EABEF335B}
 	EndGlobalSection
 EndGlobal

--- a/Chapter-2-modules-separation/Src/Fitnet.sln
+++ b/Chapter-2-modules-separation/Src/Fitnet.sln
@@ -36,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Passes.Api", "Fitnet
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Passes.DataAccess", "Fitnet.Passes.DataAccess\Fitnet.Passes.DataAccess.csproj", "{BE4822A9-64F1-449B-9EBE-918BAA67CD07}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fitnet.Passes.IntegrationTests", "Fitnet.Passes.IntegrationTests\Fitnet.Passes.IntegrationTests.csproj", "{C5DFEF2C-3AB4-4C7D-BFB5-097537FDA307}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +100,10 @@ Global
 		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE4822A9-64F1-449B-9EBE-918BAA67CD07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5DFEF2C-3AB4-4C7D-BFB5-097537FDA307}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5DFEF2C-3AB4-4C7D-BFB5-097537FDA307}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5DFEF2C-3AB4-4C7D-BFB5-097537FDA307}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5DFEF2C-3AB4-4C7D-BFB5-097537FDA307}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9A6E0883-EE26-4A50-9114-AF1EDD82EB94} = {7D3193F0-C731-4683-893F-53CE8087D7E2}
@@ -111,5 +117,6 @@ Global
 		{7BE78BF9-6419-412C-A766-F80ADFF2CF49} = {8ECA26D2-A5A3-4CC5-BED7-F33422EACEAF}
 		{BD63790A-A2CD-494F-BA6B-66FB43CA5461} = {732AD772-11C2-4DCC-B6DC-D59EABEF335B}
 		{BE4822A9-64F1-449B-9EBE-918BAA67CD07} = {732AD772-11C2-4DCC-B6DC-D59EABEF335B}
+		{C5DFEF2C-3AB4-4C7D-BFB5-097537FDA307} = {732AD772-11C2-4DCC-B6DC-D59EABEF335B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR includes work related to creation of passes projects:

- Passes.Api responsible for the endpoints used to access passes
- Passes.DataAccess responsible for database operations (and some business logic if any)
- Passes.IntegrationTests for integration tests of passes module

The next step is to move the production code of Passes module to Api and DataAccess projects.