### PR TITLE
Add packages versioning (at the moment manual)

### DIFF
--- a/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
+++ b/Chapter-3-microservice-extraction/Fitnet.Common/Directory.Build.props
@@ -9,6 +9,7 @@
         <Nullable>enable</Nullable>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <RepositoryUrl>https://github.com/meaboutsoftware/evolutionary-architecture</RepositoryUrl>
+        <Version>1.0.1</Version>
     </PropertyGroup>
     
     <ItemGroup>


### PR DESCRIPTION
This PR adds the versioning of packages. At the moment we have to remember to adjust it every time we touch the Common project - and this is a disadvantage that cannot be accepted in production code, however to simplify our work in this solution (where it does not relate directly to evolutionary architecture) it is kept this way.