### PR TITLE
Fix inconsistencies in Architecture Decision Logs

### DIFF
--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0001-record-architecture-decisions.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0001-record-architecture-decisions.adoc
@@ -1,4 +1,4 @@
-# 1. Record architecture decisions
+= 1. Record architecture decisions
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0002-use-one-project.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0002-use-one-project.adoc
@@ -1,4 +1,4 @@
-# 2. Use one project
+= 2. Use one project
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0003-use-modules.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0003-use-modules.adoc
@@ -1,4 +1,4 @@
-# 3. Use modules
+= 3. Use modules
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0004-use-separate-database-schemas.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0004-use-separate-database-schemas.adoc
@@ -1,4 +1,4 @@
-# 4. Use separate database schemas
+= 4. Use separate database schemas
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0005-use-vertical-slices.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0005-use-vertical-slices.adoc
@@ -1,4 +1,4 @@
-# 5. Use vertical slices
+= 5. Use vertical slices
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0006-use-docker.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0006-use-docker.adoc
@@ -1,4 +1,4 @@
-# 6. Use Docker
+= 6. Use Docker
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0007-use-in-memory-event-bus.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0007-use-in-memory-event-bus.adoc
@@ -1,4 +1,4 @@
-# 7. Use in-memory event bus
+= 7. Use in-memory event bus
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0008-use-internal-sealed-as-default.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0008-use-internal-sealed-as-default.adoc
@@ -1,4 +1,4 @@
-# 8. Use internal sealed as default 
+= 8. Use internal sealed as default 
 
 Date: 2023-04-15
 

--- a/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0009-select-testing-strategy.adoc
+++ b/Chapter-1-initial-architecture/Docs/ArchitectureDecisionLog/0009-select-testing-strategy.adoc
@@ -1,4 +1,4 @@
-# 9. Select testing strategy
+= 9. Select testing strategy
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0001-record-architecture-decisions.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0001-record-architecture-decisions.adoc
@@ -1,4 +1,4 @@
-# 1. Record architecture decisions
+= 1. Record architecture decisions
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0002-use-one-project.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0002-use-one-project.adoc
@@ -1,4 +1,4 @@
-# 2. Use one project
+= 2. Use one project
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0003-use-modules.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0003-use-modules.adoc
@@ -1,4 +1,4 @@
-# 3. Use modules
+= 3. Use modules
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0004-use-separate-database-schemas.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0004-use-separate-database-schemas.adoc
@@ -1,4 +1,4 @@
-# 4. Use separate database schemas
+= 4. Use separate database schemas
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0005-use-vertical-slices.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0005-use-vertical-slices.adoc
@@ -1,4 +1,4 @@
-# 5. Use vertical slices
+= 5. Use vertical slices
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0006-use-docker.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0006-use-docker.adoc
@@ -1,4 +1,4 @@
-# 6. Use Docker
+= 6. Use Docker
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0007-use-in-memory-event-bus.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0007-use-in-memory-event-bus.adoc
@@ -1,4 +1,4 @@
-# 7. Use in-memory event bus
+= 7. Use in-memory event bus
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0008-use-internal-sealed-as-default.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0008-use-internal-sealed-as-default.adoc
@@ -1,4 +1,4 @@
-# 8. Use internal sealed as default 
+= 8. Use internal sealed as default 
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0009-select-testing-strategy.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0009-select-testing-strategy.adoc
@@ -1,4 +1,4 @@
-# 9. Select testing strategy
+= 9. Select testing strategy
 
 Date: 2023-04-15
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0012-applying-layered-approach-to-passes-module.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0012-applying-layered-approach-to-passes-module.adoc
@@ -1,6 +1,8 @@
 = 12: Applying layered approach to the Passes module
 
-== Context
+Date: 2023-05-24
+
+== Problem
 The Passes module within our application has been identified as having low technical and business complexity.
 After domain and business analysis, we have recognized this module as a potential candidate to grow with some business logic.
 

--- a/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0013-use-shared-integration-events.adoc
+++ b/Chapter-2-modules-separation/Docs/ArchitectureDecisionLog/0013-use-shared-integration-events.adoc
@@ -2,7 +2,7 @@
 
 Date: 2023-05-24
 
-== Context
+== Problem
 Modules must communicate with each other in some way. We started our application development with in-memory event bus and would like to continue with it until the need to extract a microservice. When all modules were in one solution, it was easy to define one event and share them between sender and receiver. With modular-monolith we had to decide what to do - should we keep local contracts in each module (and then need to redevelop in-memory event bus or replace it with some message queue) or just create another project for a module which sends the integration event (and that can be referenced by receiver).
 
 == Decision

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0001-record-architecture-decisions.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0001-record-architecture-decisions.adoc
@@ -1,4 +1,4 @@
-# 1. Record architecture decisions
+= 1. Record architecture decisions
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0002-use-one-project.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0002-use-one-project.adoc
@@ -1,4 +1,4 @@
-# 2. Use one project
+= 2. Use one project
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0003-use-modules.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0003-use-modules.adoc
@@ -1,4 +1,4 @@
-# 3. Use modules
+= 3. Use modules
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0004-use-separate-database-schemas.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0004-use-separate-database-schemas.adoc
@@ -1,4 +1,4 @@
-# 4. Use separate database schemas
+= 4. Use separate database schemas
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0005-use-vertical-slices.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0005-use-vertical-slices.adoc
@@ -1,4 +1,4 @@
-# 5. Use vertical slices
+= 5. Use vertical slices
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0006-use-docker.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0006-use-docker.adoc
@@ -1,4 +1,4 @@
-# 6. Use Docker
+= 6. Use Docker
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0007-use-in-memory-event-bus.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0007-use-in-memory-event-bus.adoc
@@ -1,4 +1,4 @@
-# 7. Use in-memory event bus
+= 7. Use in-memory event bus
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0008-use-internal-sealed-as-default.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0008-use-internal-sealed-as-default.adoc
@@ -1,4 +1,4 @@
-# 8. Use internal sealed as default 
+= 8. Use internal sealed as default 
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0009-select-testing-strategy.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0009-select-testing-strategy.adoc
@@ -1,4 +1,4 @@
-# 9. Select testing strategy
+= 9. Select testing strategy
 
 Date: 2023-04-15
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0012-applying-layered-approach-to-passes-module.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0012-applying-layered-approach-to-passes-module.adoc
@@ -1,6 +1,8 @@
 = 12: Applying layered approach to the Passes module
 
-== Context
+Date: 2023-05-24
+
+== Problem
 The Passes module within our application has been identified as having low technical and business complexity.
 After domain and business analysis, we have recognized this module as a potential candidate to grow with some business logic.
 

--- a/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0013-use-shared-integration-events.adoc
+++ b/Chapter-3-microservice-extraction/Docs/ArchitectureDecisionLog/0013-use-shared-integration-events.adoc
@@ -2,7 +2,7 @@
 
 Date: 2023-05-24
 
-== Context
+== Problem
 Modules must communicate with each other in some way. We started our application development with in-memory event bus and would like to continue with it until the need to extract a microservice. When all modules were in one solution, it was easy to define one event and share them between sender and receiver. With modular-monolith we had to decide what to do - should we keep local contracts in each module (and then need to redevelop in-memory event bus or replace it with some message queue) or just create another project for a module which sends the integration event (and that can be referenced by receiver).
 
 == Decision


### PR DESCRIPTION
This PR contains changes related to architecture decision log in all chapters:

- fix of md headers (instead use adoc ones)
- fix of headers texts