### PR TITLE
Rename shared to common to stay consistent with other chapters

### DIFF
--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/Configuration/ConfigurationExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/Configuration/ConfigurationExtensions.cs
@@ -1,9 +1,9 @@
 namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.Configuration;
 
 using System.Reflection;
-using Fitnet.Shared.Events.EventBus;
-using Fitnet.Shared.Events.EventBus.InMemory;
-using Fitnet.Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus.InMemory;
+using EvolutionaryArchitecture.Fitnet.Common.SystemClock;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using SystemClock;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/IntegrationEvents/Handlers/IntegrationEventHandlerScope.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/IntegrationEvents/Handlers/IntegrationEventHandlerScope.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.IntegrationEvents.Handlers;
 
-using Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
 using MediatR;
 
 internal sealed class IntegrationEventHandlerScope<TIntegrationEvent> : IDisposable 

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/SystemClock/FakeSystemClock.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Common/TestEngine/SystemClock/FakeSystemClock.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Common.TestEngine.SystemClock;
 
-using EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Common.SystemClock;
 
 internal sealed class FakeSystemClock : ISystemClock
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
@@ -4,7 +4,7 @@ using EvolutionaryArchitecture.Fitnet.Contracts;
 using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract;
 using Common.TestEngine;
 using Common.TestEngine.Configuration;
-using Fitnet.Shared.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Common.ErrorHandling;
 
 public sealed class PrepareContractTests : IClassFixture<WebApplicationFactory<Program>>,
     IClassFixture<DatabaseContainer>

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -6,8 +6,8 @@ using EvolutionaryArchitecture.Fitnet.Contracts.SignContract;
 using PrepareContract;
 using Common.TestEngine.Configuration;
 using Fitnet.Contracts.SignContract.Events;
-using Fitnet.Shared.ErrorHandling;
-using Fitnet.Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 
 public sealed class SignContractTests : IClassFixture<WebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Offers/Prepare/PrepareOfferTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Offers/Prepare/PrepareOfferTests.cs
@@ -4,7 +4,8 @@ using Common.TestEngine.Configuration;
 using Common.TestEngine.IntegrationEvents.Handlers;
 using Fitnet.Offers.Prepare;
 using Fitnet.Passes.MarkPassAsExpired.Events;
-using Fitnet.Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
+
 
 public sealed class PrepareOfferTests : IClassFixture<WebApplicationFactory<Program>>,
     IClassFixture<DatabaseContainer>

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/MarkPassAsExpired/MarkPassAsExpiredTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/MarkPassAsExpired/MarkPassAsExpiredTests.cs
@@ -4,7 +4,7 @@ using Fitnet.Passes;
 using RegisterPass;
 using Common.TestEngine.Configuration;
 using Common.TestEngine.IntegrationEvents.Handlers;
-using Fitnet.Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 using Fitnet.Contracts.SignContract.Events;
 using Fitnet.Passes.GetAllPasses;
 using Fitnet.Passes.MarkPassAsExpired.Events;

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
@@ -4,7 +4,7 @@ using Common.TestEngine.Configuration;
 using Common.TestEngine.IntegrationEvents.Handlers;
 using Fitnet.Contracts.SignContract.Events;
 using Fitnet.Passes.RegisterPass.Events;
-using Fitnet.Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 
 public sealed class RegisterPassTests : IClassFixture<WebApplicationFactory<Program>>, 
     IClassFixture<DatabaseContainer>

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEvent.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
 
-using Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
 
 internal record FakeEvent(Guid Id, DateTimeOffset OccurredDateTime, bool Consumed) : IIntegrationEvent
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEventConsumer.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/FakeEventConsumer.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
 
-using Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
 
 internal sealed class TestEventConsumer: IIntegrationEventHandler<FakeEvent>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/InMemoryEventBusTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.IntegrationTests/Shared/Events/EventBus/InMemory/InMemoryEventBusTests.cs
@@ -1,7 +1,7 @@
 namespace EvolutionaryArchitecture.Fitnet.IntegrationTests.Shared.Events.EventBus.InMemory;
 
 using Common.TestEngine.Configuration;
-using Fitnet.Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 
 public sealed class InMemoryEventBusTests : IClassFixture<WebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/BusinessRuleValidatorTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/BusinessRuleValidatorTests.cs
@@ -1,4 +1,4 @@
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 namespace EvolutionaryArchitecture.Fitnet.UnitTests.BusinessRulesEngine;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/FakeBusinessRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/BusinessRulesEngine/FakeBusinessRule.cs
@@ -1,6 +1,6 @@
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
-
 namespace EvolutionaryArchitecture.Fitnet.UnitTests.BusinessRulesEngine;
+
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 internal sealed class FakeBusinessRule : IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRuleTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRuleTests.cs
@@ -1,7 +1,7 @@
 namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
 
 using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 public sealed class ContractCanBePreparedOnlyForAdultRuleTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRuleTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRuleTests.cs
@@ -1,7 +1,7 @@
 namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
 
 using EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 public sealed class CustomerMustBeSmallerThanMaximumHeightLimitRuleTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/PreviousContractHasToBeSignedRuleTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/PrepareContract/BusinessRules/PreviousContractHasToBeSignedRuleTests.cs
@@ -1,7 +1,7 @@
 namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.PrepareContract.BusinessRules;
 
 using Fitnet.Contracts.PrepareContract.BusinessRules;
-using Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 public sealed class PreviousContractHasToBeSignedRuleTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparationTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparationTests.cs
@@ -1,7 +1,7 @@
 namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.SignContract.BusinessRules;
 
 using EvolutionaryArchitecture.Fitnet.Contracts.SignContract.BusinessRules;
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 public sealed class ContractCanOnlyBeSignedWithin30DaysFromPreparationTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/SignContract/SignContractTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/Contracts/SignContract/SignContractTests.cs
@@ -2,7 +2,6 @@ namespace EvolutionaryArchitecture.Fitnet.UnitTests.Contracts.SignContract;
 
 using Fitnet.Contracts.Data;
 using PrepareContract;
-using Shared.SystemClock;
 
 public class SignContractTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/ExceptionMiddlewareTests.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet.UnitTests/ExceptionMiddlewareTests.cs
@@ -1,10 +1,10 @@
 namespace EvolutionaryArchitecture.Fitnet.UnitTests;
 
+using EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
+using Common.ErrorHandling;
 using System.Net;
 using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
-using Shared.ErrorHandling;
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
 
 public sealed class ExceptionMiddlewareTests
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/BusinessRulesEngine/BusinessRuleValidationException.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/BusinessRulesEngine/BusinessRuleValidationException.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 internal class BusinessRuleValidationException : InvalidOperationException
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/BusinessRulesEngine/BusinessRuleValidator.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/BusinessRulesEngine/BusinessRuleValidator.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 internal static class BusinessRuleValidator
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/BusinessRulesEngine/IBusinessRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/BusinessRulesEngine/IBusinessRule.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+namespace EvolutionaryArchitecture.Fitnet.Common.BusinessRulesEngine;
 
 internal interface IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/ErrorHandling/ErrorHandlingExtensions.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/ErrorHandling/ErrorHandlingExtensions.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.ErrorHandling;
+namespace EvolutionaryArchitecture.Fitnet.Common.ErrorHandling;
 
 internal static class ErrorHandlingExtensions
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/ErrorHandling/ExceptionMiddleware.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/ErrorHandling/ExceptionMiddleware.cs
@@ -1,8 +1,8 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.ErrorHandling;
+namespace EvolutionaryArchitecture.Fitnet.Common.ErrorHandling;
 
 using System.Net;
 using System.Text.Json;
-using EvolutionaryArchitecture.Fitnet.Shared.BusinessRulesEngine;
+using BusinessRulesEngine;
 
 internal sealed class ExceptionMiddleware
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/EventBusModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/EventBusModule.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus;
+namespace EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 
 using System.Reflection;
 using InMemory;

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/IEventBus.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/IEventBus.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus;
+namespace EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 
 internal interface IEventBus
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/InMemory/InMemoryEventBus.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/InMemory/InMemoryEventBus.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.Common.Events.EventBus.InMemory;
 
 using MediatR;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/InMemory/InMemoryEventBusModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/EventBus/InMemory/InMemoryEventBusModule.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus.InMemory;
+namespace EvolutionaryArchitecture.Fitnet.Common.Events.EventBus.InMemory;
 
 using System.Reflection;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/IIntegrationEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/IIntegrationEvent.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.Events;
+namespace EvolutionaryArchitecture.Fitnet.Common.Events;
 
 using MediatR;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/IIntegrationEventHandler.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/Events/IIntegrationEventHandler.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.Events;
+namespace EvolutionaryArchitecture.Fitnet.Common.Events;
 
 using MediatR;
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/SystemClock/ISystemClock.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/SystemClock/ISystemClock.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.Common.SystemClock;
 
 internal interface ISystemClock
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/SystemClock/SystemClock.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/SystemClock/SystemClock.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.Common.SystemClock;
 
 internal sealed class SystemClock : ISystemClock
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Common/SystemClock/SystemClockModule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Common/SystemClock/SystemClockModule.cs
@@ -1,4 +1,4 @@
-namespace EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
+namespace EvolutionaryArchitecture.Fitnet.Common.SystemClock;
 
 internal static class SystemClockModule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Contract.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/Data/Contract.cs
@@ -1,9 +1,8 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.Data;
 
+using Common.BusinessRulesEngine;
 using PrepareContract.BusinessRules;
 using SignContract.BusinessRules;
-using Shared.BusinessRulesEngine;
-using Shared.SystemClock;
 
 internal sealed class Contract
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/ContractCanBePreparedOnlyForAdultRule.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
 
-using Shared.BusinessRulesEngine;
+using Common.BusinessRulesEngine;
 
 internal sealed class ContractCanBePreparedOnlyForAdultRule : IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/CustomerMustBeSmallerThanMaximumHeightLimitRule.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
 
-using Shared.BusinessRulesEngine;
+using Common.BusinessRulesEngine;
 
 internal sealed class CustomerMustBeSmallerThanMaximumHeightLimitRule : IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/PreviousContractHasToBeSignedRule.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/PrepareContract/BusinessRules/PreviousContractHasToBeSignedRule.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.PrepareContract.BusinessRules;
 
-using Shared.BusinessRulesEngine;
+using Common.BusinessRulesEngine;
 
 internal sealed class PreviousContractHasToBeSignedRule : IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparation.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/BusinessRules/ContractCanOnlyBeSignedWithin30DaysFromPreparation.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.SignContract.BusinessRules;
 
-using Shared.BusinessRulesEngine;
+using Common.BusinessRulesEngine;
 
 internal sealed class ContractCanOnlyBeSignedWithin30DaysFromPreparation : IBusinessRule
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/Events/ContractSignedEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/Events/ContractSignedEvent.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Contracts.SignContract.Events;
 
-using EvolutionaryArchitecture.Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
 
 internal record ContractSignedEvent(Guid Id, Guid ContractId, Guid ContractCustomerId, DateTimeOffset SignedAt, DateTimeOffset ExpireAt, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/SignContractEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Contracts/SignContract/SignContractEndpoint.cs
@@ -2,8 +2,8 @@ namespace EvolutionaryArchitecture.Fitnet.Contracts.SignContract;
 
 using Data.Database;
 using Events;
-using Shared.Events.EventBus;
-using Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
+using Common.SystemClock;
 
 internal static class SignContractEndpoint
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/OfferPrepareEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/OfferPrepareEvent.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Offers.Prepare;
 
-using Shared.Events;
+using Common.Events;
 
 internal sealed record OfferPrepareEvent(Guid Id, Guid OfferId, Guid CustomerId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/PassExpiredEventHandler.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Offers/Prepare/PassExpiredEventHandler.cs
@@ -3,9 +3,9 @@ namespace EvolutionaryArchitecture.Fitnet.Offers.Prepare;
 using Data;
 using Data.Database;
 using Passes.MarkPassAsExpired.Events;
-using Shared.Events;
-using Shared.Events.EventBus;
-using Shared.SystemClock;
+using Common.Events;
+using Common.Events.EventBus;
+using Common.SystemClock;
 
 internal sealed class PassExpiredEventHandler : IIntegrationEventHandler<PassExpiredEvent>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/Events/PassExpiredEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/Events/PassExpiredEvent.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Passes.MarkPassAsExpired.Events;
 
-using EvolutionaryArchitecture.Fitnet.Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
 
 internal record PassExpiredEvent(Guid Id, Guid PassId, Guid CustomerId, DateTimeOffset OccurredDateTime) : IIntegrationEvent
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/MarkPassAsExpired/MarkPassAsExpiredEndpoint.cs
@@ -2,8 +2,8 @@ namespace EvolutionaryArchitecture.Fitnet.Passes.MarkPassAsExpired;
 
 using Data.Database;
 using Events;
-using Shared.Events.EventBus;
-using Shared.SystemClock;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
+using Common.SystemClock;
 
 internal static class MarkPassAsExpiredEndpoint
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/Events/PassRegisteredEvent.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/Events/PassRegisteredEvent.cs
@@ -1,6 +1,6 @@
 namespace EvolutionaryArchitecture.Fitnet.Passes.RegisterPass.Events;
 
-using Shared.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
 
 internal record PassRegisteredEvent (Guid Id, Guid PassId, DateTimeOffset OccurredDateTime): IIntegrationEvent
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/RegisterEndpoint.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Passes/RegisterPass/RegisterEndpoint.cs
@@ -4,8 +4,8 @@ using Contracts.SignContract.Events;
 using Data;
 using Data.Database;
 using Events;
-using Shared.Events;
-using Shared.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.Events;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
 
 internal sealed class ContractSignedEventHandler : IIntegrationEventHandler<ContractSignedEvent>
 {

--- a/Chapter-1-initial-architecture/Src/Fitnet/Program.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Program.cs
@@ -1,10 +1,10 @@
+using EvolutionaryArchitecture.Fitnet.Common.ErrorHandling;
+using EvolutionaryArchitecture.Fitnet.Common.Events.EventBus;
+using EvolutionaryArchitecture.Fitnet.Common.SystemClock;
 using EvolutionaryArchitecture.Fitnet.Contracts;
 using EvolutionaryArchitecture.Fitnet.Offers;
 using EvolutionaryArchitecture.Fitnet.Passes;
 using EvolutionaryArchitecture.Fitnet.Reports;
-using EvolutionaryArchitecture.Fitnet.Shared.ErrorHandling;
-using EvolutionaryArchitecture.Fitnet.Shared.Events.EventBus;
-using EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
+++ b/Chapter-1-initial-architecture/Src/Fitnet/Reports/GenerateNewPassesRegistrationsPerMonthReport/DataRetriever/NewPassesRegistrationPerMonthReportDataRetriever.cs
@@ -2,8 +2,8 @@ namespace EvolutionaryArchitecture.Fitnet.Reports.GenerateNewPassesRegistrations
 
 using Dapper;
 using Dtos;
-using EvolutionaryArchitecture.Fitnet.Reports.DataAccess;
-using EvolutionaryArchitecture.Fitnet.Shared.SystemClock;
+using DataAccess;
+using Common.SystemClock;
 
 internal sealed class NewPassesRegistrationPerMonthReportDataRetriever : INewPassesRegistrationPerMonthReportDataRetriever
 {


### PR DESCRIPTION
This PR contains work that is related to renaming of shared folder to common, to stay consistent with the next chapters where "Common" is used.